### PR TITLE
Grape helpers for JWT authentication

### DIFF
--- a/app/helpers/jwt_auth_helpers.rb
+++ b/app/helpers/jwt_auth_helpers.rb
@@ -1,0 +1,17 @@
+module JWTAuthHelpers
+  def current_user
+   user_info_from_header ? User.find_by(id:user_info_from_header.user_id) : nil
+  rescue JWT::DecodeError
+    nil
+  end
+
+  def authenticate_user!
+    error!({message: "Authentication failure"}, 401) unless current_user
+  end
+
+  private
+  def user_info_from_header
+    return nil unless @user_info || (headers["Authorization"] && headers["Authorization"].split(" ").first == "Bearer")
+    @user_info ||= AuthToken.decode headers["Authorization"].split(" ").last
+  end
+end

--- a/app/helpers/jwt_auth_helpers.rb
+++ b/app/helpers/jwt_auth_helpers.rb
@@ -1,6 +1,6 @@
 module JWTAuthHelpers
   def current_user
-   user_info_from_header ? User.find_by(id:user_info_from_header.user_id) : nil
+   user_info_from_header ? User.find_by(id: user_info_from_header["user_id"]) : nil
   rescue JWT::DecodeError
     nil
   end

--- a/app/helpers/jwt_auth_helpers.rb
+++ b/app/helpers/jwt_auth_helpers.rb
@@ -1,17 +1,18 @@
 module JWTAuthHelpers
   def current_user
-   user_info_from_header ? User.find_by(id: user_info_from_header["user_id"]) : nil
+    user_info_from_header ? User.find_by(id: user_info_from_header['user_id']) : nil
   rescue JWT::DecodeError
     nil
   end
 
   def authenticate_user!
-    error!({message: "Authentication failure"}, 401) unless current_user
+    error!({ message: 'Authentication failure' }, 401) unless current_user
   end
 
   private
+
   def user_info_from_header
-    return nil unless @user_info || (headers["Authorization"] && headers["Authorization"].split(" ").first == "Bearer")
-    @user_info ||= AuthToken.decode headers["Authorization"].split(" ").last
+    return nil unless @user_info || (headers['Authorization'] && headers['Authorization'].split(' ').first == 'Bearer')
+    @user_info ||= AuthToken.decode headers['Authorization'].split(' ').last
   end
 end

--- a/spec/helpers/jwt_auth_helpers_spec.rb
+++ b/spec/helpers/jwt_auth_helpers_spec.rb
@@ -1,0 +1,112 @@
+require 'rails_helper'
+
+RSpec.describe JWTAuthHelpers, type: :helper do
+  describe "#user_info_from_header" do
+    it "should return nil when the request does not have an Authorization header" do
+      allow(helper).to receive(:headers).and_return({})
+      expect(helper.send :user_info_from_header).to eq(nil)
+    end
+
+    it "should return nil when the request has an Authorization header that does not start with 'Bearer'" do
+      allow(helper).to receive(:headers).and_return({"Authorization" => "Invalid Stuff"})
+      expect(helper.send :user_info_from_header).to eq(nil)
+    end
+
+    it "should raise a JWT error when the request has an Authorization header with an invalid JWT token" do
+      allow(helper).to receive(:headers).and_return({"Authorization" => "Bearer invalid.token.here"})
+      expect{helper.send :user_info_from_header}.to raise_error(JWT::DecodeError)
+    end
+
+    it "should return a hash with the encoded payload when the request has an Authorization header with a valid JWT token" do
+      token = AuthToken.encode({payload: "value", payload_2: "value_2"})
+      allow(helper).to receive(:headers).and_return({"Authorization" => "Bearer #{token}"})
+      expect(helper.send(:user_info_from_header)[:payload]).to eq("value")
+      expect(helper.send(:user_info_from_header)[:payload_2]).to eq("value_2")
+    end
+  end
+
+  describe "#current_user" do
+    it "should return nil when the request does not have an Authorization header" do
+      allow(helper).to receive(:headers).and_return({})
+      expect(helper.current_user).to eq(nil)
+    end
+
+    it "should return nil when the request has an Authorization header that does not start with 'Bearer'" do
+      allow(helper).to receive(:headers).and_return({"Authorization" => "Invalid Stuff"})
+      expect(helper.current_user).to eq(nil)
+    end
+
+    it "should return nil when the request has an Authorization header with an invalid JWT token" do
+      allow(helper).to receive(:headers).and_return({"Authorization" => "Bearer invalid.token.here"})
+      expect(helper.current_user).to eq(nil)
+    end
+
+    it "should return nil when the request has an Authorization header with a JWT token that does not have a user ID" do
+      token = AuthToken.encode({stuff: "more stuff"})
+      allow(helper).to receive(:headers).and_return({"Authorization" => "Bearer #{token}"})
+      expect(helper.current_user).to eq(nil)
+    end
+
+    it "should return nil when the request has an Authorization header with a JWT token that does not contain a valid user ID" do
+      last_user = User.last
+      invalid_id = last_user ? last_user.id + 1 : 1
+      token = AuthToken.encode({user_id: invalid_id})
+      allow(helper).to receive(:headers).and_return({"Authorization" => "Bearer #{token}"})
+      expect(helper.current_user).to eq(nil)
+    end
+
+    it "should return the matching user when the request has an Authorization header with a JWT token that contains a valid user ID" do
+      user = create :user
+      token = AuthToken.encode({user_id: user.id})
+      allow(helper).to receive(:headers).and_return({"Authorization" => "Bearer #{token}"})
+      expect(helper.current_user).to eq(user)
+    end
+  end
+
+  describe "#authenticate_user!" do
+    before(:each) {helper.define_singleton_method(:error!) {|content, status|}}
+     
+    describe "without a valid header/JWT token" do
+      before (:each) {expect(helper).to receive(:error!).with({message: "Authentication failure"}, 401)}
+
+      it "should call the error! method with the right params when the request does not have an Authorization header" do
+        allow(helper).to receive(:headers).and_return({})
+        helper.authenticate_user!
+      end
+
+      it "should call the error! method with the right params when the Authorization header does not start with 'Bearer'" do
+        allow(helper).to receive(:headers).and_return({"Authorization" => "Invalid Stuff"})
+        helper.authenticate_user!
+      end
+  
+      it "should call the error! method with the right params when the Authorization header has an invalid JWT token" do
+        allow(helper).to receive(:headers).and_return({"Authorization" => "Bearer invalid.token.here"})
+        helper.authenticate_user!
+      end
+
+      it "should call the error! method with the right params when the JWT token does not have a user ID" do
+        token = AuthToken.encode({stuff: "more stuff"})
+        allow(helper).to receive(:headers).and_return({"Authorization" => "Bearer #{token}"})
+        helper.authenticate_user!
+      end
+
+      it "should call the error! method with the right params when the JWT token does not contain a valid user ID" do
+        last_user = User.last
+        invalid_id = last_user ? last_user.id + 1 : 1 
+        token = AuthToken.encode({user_id: invalid_id})
+        allow(helper).to receive(:headers).and_return({"Authorization" => "Bearer #{token}"})
+        helper.authenticate_user!
+      end
+    end
+
+    describe "with a valid header and JWT token" do
+      it "should not call the error! method when the JWT token contains a valid user ID" do
+        user = create :user
+        token = AuthToken.encode({user_id: user.id})
+        allow(helper).to receive(:headers).and_return({"Authorization" => "Bearer #{token}"})
+        expect(helper).to_not receive(:error!)
+        helper.authenticate_user!
+      end
+    end
+  end
+end

--- a/spec/helpers/jwt_auth_helpers_spec.rb
+++ b/spec/helpers/jwt_auth_helpers_spec.rb
@@ -1,109 +1,109 @@
 require 'rails_helper'
 
 RSpec.describe JWTAuthHelpers, type: :helper do
-  describe "#user_info_from_header" do
-    it "should return nil when the request does not have an Authorization header" do
+  describe '#user_info_from_header' do
+    it 'should return nil when the request does not have an Authorization header' do
       allow(helper).to receive(:headers).and_return({})
-      expect(helper.send :user_info_from_header).to eq(nil)
+      expect(helper.send(:user_info_from_header)).to eq(nil)
     end
 
     it "should return nil when the request has an Authorization header that does not start with 'Bearer'" do
-      allow(helper).to receive(:headers).and_return({"Authorization" => "Invalid Stuff"})
-      expect(helper.send :user_info_from_header).to eq(nil)
+      allow(helper).to receive(:headers).and_return('Authorization' => 'Invalid Stuff')
+      expect(helper.send(:user_info_from_header)).to eq(nil)
     end
 
-    it "should raise a JWT error when the request has an Authorization header with an invalid JWT token" do
-      allow(helper).to receive(:headers).and_return({"Authorization" => "Bearer invalid.token.here"})
-      expect{helper.send :user_info_from_header}.to raise_error(JWT::DecodeError)
+    it 'should raise a JWT error when the request has an Authorization header with an invalid JWT token' do
+      allow(helper).to receive(:headers).and_return('Authorization' => 'Bearer invalid.token.here')
+      expect { helper.send :user_info_from_header }.to raise_error(JWT::DecodeError)
     end
 
-    it "should return a hash with the encoded payload when the request has an Authorization header with a valid JWT token" do
-      token = AuthToken.encode({payload: "value", payload_2: "value_2"})
-      allow(helper).to receive(:headers).and_return({"Authorization" => "Bearer #{token}"})
-      expect(helper.send(:user_info_from_header)[:payload]).to eq("value")
-      expect(helper.send(:user_info_from_header)[:payload_2]).to eq("value_2")
+    it 'should return a hash with the encoded payload when the request has an Authorization header with a valid JWT token' do
+      token = AuthToken.encode(payload: 'value', payload_2: 'value_2')
+      allow(helper).to receive(:headers).and_return('Authorization' => "Bearer #{token}")
+      expect(helper.send(:user_info_from_header)[:payload]).to eq('value')
+      expect(helper.send(:user_info_from_header)[:payload_2]).to eq('value_2')
     end
   end
 
-  describe "#current_user" do
-    it "should return nil when the request does not have an Authorization header" do
+  describe '#current_user' do
+    it 'should return nil when the request does not have an Authorization header' do
       allow(helper).to receive(:headers).and_return({})
       expect(helper.current_user).to eq(nil)
     end
 
     it "should return nil when the request has an Authorization header that does not start with 'Bearer'" do
-      allow(helper).to receive(:headers).and_return({"Authorization" => "Invalid Stuff"})
+      allow(helper).to receive(:headers).and_return('Authorization' => 'Invalid Stuff')
       expect(helper.current_user).to eq(nil)
     end
 
-    it "should return nil when the request has an Authorization header with an invalid JWT token" do
-      allow(helper).to receive(:headers).and_return({"Authorization" => "Bearer invalid.token.here"})
+    it 'should return nil when the request has an Authorization header with an invalid JWT token' do
+      allow(helper).to receive(:headers).and_return('Authorization' => 'Bearer invalid.token.here')
       expect(helper.current_user).to eq(nil)
     end
 
-    it "should return nil when the request has an Authorization header with a JWT token that does not have a user ID" do
-      token = AuthToken.encode({stuff: "more stuff"})
-      allow(helper).to receive(:headers).and_return({"Authorization" => "Bearer #{token}"})
+    it 'should return nil when the request has an Authorization header with a JWT token that does not have a user ID' do
+      token = AuthToken.encode(stuff: 'more stuff')
+      allow(helper).to receive(:headers).and_return('Authorization' => "Bearer #{token}")
       expect(helper.current_user).to eq(nil)
     end
 
-    it "should return nil when the request has an Authorization header with a JWT token that does not contain a valid user ID" do
+    it 'should return nil when the request has an Authorization header with a JWT token that does not contain a valid user ID' do
       last_user = User.last
       invalid_id = last_user ? last_user.id + 1 : 1
-      token = AuthToken.encode({user_id: invalid_id})
-      allow(helper).to receive(:headers).and_return({"Authorization" => "Bearer #{token}"})
+      token = AuthToken.encode(user_id: invalid_id)
+      allow(helper).to receive(:headers).and_return('Authorization' => "Bearer #{token}")
       expect(helper.current_user).to eq(nil)
     end
 
-    it "should return the matching user when the request has an Authorization header with a JWT token that contains a valid user ID" do
+    it 'should return the matching user when the request has an Authorization header with a JWT token that contains a valid user ID' do
       user = create :user
-      token = AuthToken.encode({user_id: user.id})
-      allow(helper).to receive(:headers).and_return({"Authorization" => "Bearer #{token}"})
+      token = AuthToken.encode(user_id: user.id)
+      allow(helper).to receive(:headers).and_return('Authorization' => "Bearer #{token}")
       expect(helper.current_user).to eq(user)
     end
   end
 
-  describe "#authenticate_user!" do
-    before(:each) {helper.define_singleton_method(:error!) {|content, status|}}
-     
-    describe "without a valid header/JWT token" do
-      before (:each) {expect(helper).to receive(:error!).with({message: "Authentication failure"}, 401)}
+  describe '#authenticate_user!' do
+    before(:each) { helper.define_singleton_method(:error!) { |content, status| } }
 
-      it "should call the error! method with the right params when the request does not have an Authorization header" do
+    describe 'without a valid header/JWT token' do
+      before(:each) { expect(helper).to receive(:error!).with({ message: 'Authentication failure' }, 401) }
+
+      it 'should call the error! method with the right params when the request does not have an Authorization header' do
         allow(helper).to receive(:headers).and_return({})
         helper.authenticate_user!
       end
 
       it "should call the error! method with the right params when the Authorization header does not start with 'Bearer'" do
-        allow(helper).to receive(:headers).and_return({"Authorization" => "Invalid Stuff"})
-        helper.authenticate_user!
-      end
-  
-      it "should call the error! method with the right params when the Authorization header has an invalid JWT token" do
-        allow(helper).to receive(:headers).and_return({"Authorization" => "Bearer invalid.token.here"})
+        allow(helper).to receive(:headers).and_return('Authorization' => 'Invalid Stuff')
         helper.authenticate_user!
       end
 
-      it "should call the error! method with the right params when the JWT token does not have a user ID" do
-        token = AuthToken.encode({stuff: "more stuff"})
-        allow(helper).to receive(:headers).and_return({"Authorization" => "Bearer #{token}"})
+      it 'should call the error! method with the right params when the Authorization header has an invalid JWT token' do
+        allow(helper).to receive(:headers).and_return('Authorization' => 'Bearer invalid.token.here')
         helper.authenticate_user!
       end
 
-      it "should call the error! method with the right params when the JWT token does not contain a valid user ID" do
+      it 'should call the error! method with the right params when the JWT token does not have a user ID' do
+        token = AuthToken.encode(stuff: 'more stuff')
+        allow(helper).to receive(:headers).and_return('Authorization' => "Bearer #{token}")
+        helper.authenticate_user!
+      end
+
+      it 'should call the error! method with the right params when the JWT token does not contain a valid user ID' do
         last_user = User.last
-        invalid_id = last_user ? last_user.id + 1 : 1 
-        token = AuthToken.encode({user_id: invalid_id})
-        allow(helper).to receive(:headers).and_return({"Authorization" => "Bearer #{token}"})
+        invalid_id = last_user ? last_user.id + 1 : 1
+        token = AuthToken.encode(user_id: invalid_id)
+        allow(helper).to receive(:headers).and_return('Authorization' => "Bearer #{token}")
         helper.authenticate_user!
       end
     end
 
-    describe "with a valid header and JWT token" do
-      it "should not call the error! method when the JWT token contains a valid user ID" do
+    describe 'with a valid header and JWT token' do
+      it 'should not call the error! method when the JWT token contains a valid user ID' do
         user = create :user
-        token = AuthToken.encode({user_id: user.id})
-        allow(helper).to receive(:headers).and_return({"Authorization" => "Bearer #{token}"})
+        token = AuthToken.encode(user_id: user.id)
+        allow(helper).to receive(:headers).and_return('Authorization' => "Bearer #{token}")
         expect(helper).to_not receive(:error!)
         helper.authenticate_user!
       end


### PR DESCRIPTION
- Created the `JWTAuthHelpers` module, which contains the following:
  - A private `user_info_from_header` method that checks whether the request has a proper header with a JWT token and attempts to decode the token and return the payload
  - A `current_user` method that returns the user associated with the current request via JWT token (if there is one)
  - An `authenticate_user!` method that throws a Grape error if there's no user associated with the current request
- Wrote unit tests for the module  
